### PR TITLE
Make letsencrypt optional by default

### DIFF
--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ func init() {
 	cli.BoolVar(&showVersion, "version", false, "display version and exit")
 	cli.BoolVar(&showHelp, "help", false, "display help and exit")
 	cli.BoolVar(&debug, "debug", false, "debug mode")
-	cli.BoolVar(&letsencrypt, "letsencrypt", true, "enable TLS using Let's Encrypt on port 443")
+	cli.BoolVar(&letsencrypt, "letsencrypt", false, "enable TLS using Let's Encrypt on port 443")
 	cli.StringVar(&httpAddr, "http-addr", ":80", "HTTP listen address")
 	cli.StringVar(&httpHost, "http-host", "", "HTTP host (required)")
 }


### PR DESCRIPTION
Fixes #5.

If it has to be set up via Docker (or not, since a single Go binary is easy to download too), I suggest to move the letsencrypt setup to "disabled" by default, and ask the user to explicitly enable it via the `-letsencrypt` command-line option.


(I'm sorry I'm totally new to Go lang, and I'm definitely NOT making this pull request because I did not find how to disable letsencrypt, be sure of that, hey, come on, it should be easy, shouldn't it?)